### PR TITLE
Update calculating brightness & saturation indices

### DIFF
--- a/lim-yen-wu.c
+++ b/lim-yen-wu.c
@@ -168,15 +168,11 @@ static void compute_global_merits(struct image *image)
 	else
 		image->merit.median_sharpness = sorted_sharpness[n/2];
 	free(sorted_sharpness);
-
-	mean_bright_sharp /= n;
-	mean_bright_blur /= n;
-	mean_sat_sharp /= n;
-	mean_sat_blur /= n;
+	
 	image->merit.composition = composition_sum/n;
-	image->merit.brightness_idx = mean_bright_sharp-mean_bright_blur;
-	image->merit.saturation_idx = mean_sat_sharp-mean_sat_blur;
-	image->merit.density = (float)sharp_count/n;
+	image->merit.brightness_idx = (float) (mean_bright_sharp/(sharp_count + EPSILON_F) - mean_bright_blur/((n - sharp_count) + EPSILON_F));
+    	image->merit.saturation_idx = (float) (mean_sat_sharp/(sharp_count + EPSILON_F) - mean_sat_blur/((n - sharp_count) + EPSILON_F));
+   	image->merit.density = (float)sharp_count / n;
 }
 
 


### PR DESCRIPTION
As per the research paper followed for building this algorithm (see: http://hplabs.hp.com/techreports/2005/HPL-2005-14.pdf), saturation index and brightness index are defined as: 
Saturation Index: To implement this, we compute the color saturation and subtracted the average color saturation of the blurry areas from that of the sharp areas. 
Brightness Index: To implement this, we compute the average brightness difference between the sharp and blurry areas. 
Proposed relevant changes required to calculate brightness and saturation index in this regard.